### PR TITLE
Add PostgreSQL-based GPT agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# Asistente Finagro
+
+Este repositorio contiene distintos asistentes basados en GPT. El archivo `Asistente.py` ofrece un servicio que analiza documentos PDF mediante GPT-4o y `chatbot.py` muestra una interfaz sencilla con Streamlit.
+
+## Nuevo agente basado en PostgreSQL
+
+El script `db_agent.py` implementa un nuevo servicio en FastAPI que permite responder preguntas basándose en la información almacenada en una base de datos PostgreSQL.
+
+### Uso
+
+1. Defina las variables de entorno necesarias para conectarse a la base de datos y a la API de OpenAI:
+
+```bash
+export OPENAI_API_KEY=<su_clave>
+export DB_HOST=<host>
+export DB_PORT=<puerto>
+export DB_NAME=<base>
+export DB_USER=<usuario>
+export DB_PASSWORD=<contraseña>
+```
+
+2. Ejecute el servicio:
+
+```bash
+python db_agent.py
+```
+
+El servidor escuchará en `http://localhost:8001/preguntar-db`. En la consulta se envía un parámetro `pregunta` con la duda en lenguaje natural.
+
+El agente genera la consulta SQL correspondiente con GPT, ejecuta la consulta en la base de datos y luego crea una respuesta basada en los datos obtenidos.
+### Instalación
+
+Instale las dependencias principales:
+
+```bash
+pip install fastapi uvicorn[standard] psycopg2-binary openai python-dotenv
+```
+
+Este servicio es útil para responder consultas analíticas o estadísticas de los datos almacenados, generando la consulta SQL y devolviendo una respuesta en lenguaje natural.

--- a/db_agent.py
+++ b/db_agent.py
@@ -1,0 +1,112 @@
+from fastapi import FastAPI, Query
+import os
+import json
+import psycopg2
+from openai import OpenAI
+from dotenv import load_dotenv
+
+load_dotenv()
+
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+DB_HOST = os.getenv("DB_HOST", "localhost")
+DB_PORT = os.getenv("DB_PORT", "5432")
+DB_NAME = os.getenv("DB_NAME")
+DB_USER = os.getenv("DB_USER")
+DB_PASSWORD = os.getenv("DB_PASSWORD")
+if not all([OPENAI_API_KEY, DB_NAME, DB_USER, DB_PASSWORD]):
+    raise RuntimeError("Faltan variables de entorno para la base de datos o la API de OpenAI")
+
+
+app = FastAPI()
+
+
+def get_db_connection():
+    return psycopg2.connect(
+        host=DB_HOST,
+        port=DB_PORT,
+        dbname=DB_NAME,
+        user=DB_USER,
+        password=DB_PASSWORD,
+    )
+
+
+def obtener_esquema() -> str:
+    """Devuelve una descripción simple del esquema de la base de datos."""
+    with get_db_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT table_name, column_name
+                FROM information_schema.columns
+                WHERE table_schema = 'public'
+                ORDER BY table_name, ordinal_position
+                """
+            )
+            filas = cur.fetchall()
+
+    esquema = {}
+    for tabla, columna in filas:
+        esquema.setdefault(tabla, []).append(columna)
+    partes = [f"{t}({', '.join(c)})" for t, c in esquema.items()]
+    return "; ".join(partes)
+
+
+SCHEMA_DESCRIPCION = obtener_esquema()
+
+
+client = OpenAI(api_key=OPENAI_API_KEY)
+
+
+def pregunta_a_sql(pregunta: str) -> str:
+    """Genera una consulta SQL a partir de la pregunta."""
+    system = (
+        "Eres un generador de SQL especializado en analisis de datos y estadistica. "
+        f"Utiliza la pregunta del usuario y el siguiente esquema: {SCHEMA_DESCRIPCION}. "
+        "Devuelve unicamente la consulta SQL e incluye LIMIT 100 cuando sea necesario."
+    )
+    res = client.chat.completions.create(
+        model="gpt-4o",
+        messages=[{"role": "system", "content": system}, {"role": "user", "content": pregunta}],
+        max_tokens=150,
+        temperature=0,
+    )
+    return res.choices[0].message.content.strip().strip(";")
+
+
+def ejecutar_sql(sql: str):
+    with get_db_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(sql)
+            filas = cur.fetchall()
+            columnas = [d[0] for d in cur.description]
+    return [dict(zip(columnas, f)) for f in filas]
+
+
+def generar_respuesta(pregunta: str, datos: list) -> str:
+    """Genera la respuesta final utilizando los datos obtenidos."""
+    mensajes = [
+        {"role": "system", "content": "Responde a la pregunta usando solo los datos proporcionados."},
+        {
+            "role": "user",
+            "content": f"Pregunta: {pregunta}\nDatos: {json.dumps(datos, ensure_ascii=False)}",
+        },
+    ]
+    res = client.chat.completions.create(model="gpt-4o", messages=mensajes, max_tokens=300)
+    return res.choices[0].message.content.strip()
+
+
+@app.get("/preguntar-db")
+def preguntar_db(pregunta: str = Query(...)):
+    sql = pregunta_a_sql(pregunta)
+    try:
+        datos = ejecutar_sql(sql)
+    except Exception as e:
+        return {"error": f"Error al ejecutar la consulta: {e}", "sql": sql}
+    respuesta = generar_respuesta(pregunta, datos)
+    return {"sql": sql, "respuesta": respuesta}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8001)


### PR DESCRIPTION
## Summary
- document how to run the new PostgreSQL agent
- implement `db_agent.py` to answer questions using a Postgres database
- expand instructions and add dependency info
- refine SQL generation prompt and check required environment variables

## Testing
- `python -m py_compile Asistente.py chatbot.py db_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_6888e457dd7c83238e5c5d0e70b8e413